### PR TITLE
Redirect old internship page to new internship job post page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ ruby '3.2.2'
 gem 'webrick'
 gem 'jekyll'
 
+gem 'jekyll-redirect-from'
+
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem 'minima'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,8 @@ GEM
       webrick (~> 1.7)
     jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
     jekyll-seo-tag (2.8.0)
@@ -76,6 +78,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   jekyll-feed
+  jekyll-redirect-from
   minima
   tzinfo-data
   webrick

--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ markdown: kramdown
 theme: minima
 plugins:
   - jekyll-feed
+  - jekyll-redirect-from
 
 cover_image: "/assets/img/slider/slider1.jpg"
 phone: +31 6 5202 8891

--- a/_posts/careers/2022-11-22-Iternship.md
+++ b/_posts/careers/2022-11-22-Iternship.md
@@ -1,0 +1,32 @@
+---
+title: Internship
+layout: featured
+author: mike_sanders
+image: /assets/img/news/brooke-cagle-g1Kr40.jpg
+redirect_to: https://ignitioncomputing.com/careers/2023/05/12/Internship
+published: false
+categories: careers
+---
+
+### About the internship
+
+Modern science requires good software. At Ignition Computing we support science and industry with the software tools to support their research. One of our projects, Preconnet, focuses on accelerating numerical simulations through machine learning. Faster and more efficient simulations will result in a lower energy consumption, lower waiting times and the possibility of higher resolution simulations.
+
+As an intern, you will participate in the ongoing research for Preconnet. By developing and training machine learning models you can contribute to the acceleration of simulations in research and industry. During your internship you will design, develop, test and implement software solutions. We encourage collaboration and personal growth.
+
+Details for this position will be based on the requirements of your institution but will in principle be 40 hours per week. You will be based in our office in Eindhoven, but occasional remote work is possible. While several projects are available, the interpretation or even the topic of your project are open for discussion.
+
+### Your profile
+
+- Currently following a Bachelor’s or Master's degree education in a technical field, for example Computer Science, Applied Mathematics or Physics.
+- Experience with software development in general purpose programming languages, for example Python.
+- Ability to speak and write in English fluently.
+- Experience with object oriented programming in Python is preferred but not necessary.
+- Experience with Unix/Linux environments is preferred but not necessary.
+- Experience with numerical simulations is preferred but not necessary.
+
+### Starting date
+
+- The starting date is flexible and can be discussed.
+
+To apply, send your internship application including CV and cover letter to <careers@ignitioncomputing.com>.


### PR DESCRIPTION
add 'jekyll-redirect-from' plugin. Additionally, the old iternship job post is relaunched but not published. Finally, in the the old iternship job post is redirect to the new one.